### PR TITLE
Event apis for creating and viewing events for specific courses

### DIFF
--- a/app/Event.php
+++ b/app/Event.php
@@ -8,7 +8,7 @@ class Event extends Model
 {
     protected $fillable = [
 
-        'title', 'description', 'date', 'place'
+        'title', 'description', 'date', 'place', 'course_id'
     ];
 
     public function calenders()

--- a/app/Http/Controllers/API/EventsAPIController.php
+++ b/app/Http/Controllers/API/EventsAPIController.php
@@ -5,12 +5,30 @@ namespace App\Http\Controllers\API;
 use App\Course;
 use App\Event;
 use Illuminate\Http\Request;
-
+use Illuminate\Support\Facades\Auth;
+use Validator;
 use App\Http\Requests;
 use App\Http\Controllers\Controller;
 
 class EventsAPIController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth', ['only' => [
+            'create'
+        ]]);
+    }
+
+    protected function validator(array $data)
+    {
+        return Validator::make($data, [
+            'title' => 'required|max:255',
+            'description' => 'required',
+            'date' => 'required',
+            'place' => 'required',
+        ]);
+    }
+
     /**
      * Return a set of events associated with a course
      *
@@ -20,8 +38,35 @@ class EventsAPIController extends Controller
     public function index($course_id)
     {
         $course = Course::find($course_id);
-        $events = $course->events()->where('verified', true)->paginate(10);
-
+        if (!$course) {
+            return response()->json(['status' => '404 not found', 'message' => 'Course not found'], 404);
+        }
+        $events = $course->events()->where('verified', false)->paginate(10);
         return response()->json($events, 200);
     }
+
+    /**
+     * Create a new event of a specific course
+     * @param $course_id
+     * @param $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function create($course_id, Request $request)
+    {
+        $course = Course::find($course_id);
+        if (!$course) {
+            return response()->json(['status' => '404 not found', 'message' => 'Course not found'], 404);
+        }
+        $validator = $this->validator($request->all());
+
+        if ($validator->fails())
+            return response()->json($validator->errors(), 302);
+
+        $event = new Event($request->all());
+        $event['course_id'] = $course_id;
+        $event['creator_id'] = Auth::user()->id;
+        $event->save();
+        return response()->json($event, 200);
+    }
+
 }

--- a/app/Http/Controllers/API/EventsAPIController.php
+++ b/app/Http/Controllers/API/EventsAPIController.php
@@ -20,7 +20,7 @@ class EventsAPIController extends Controller
     public function index($course_id)
     {
         $course = Course::find($course_id);
-        $events = $course->events()->paginate(10);
+        $events = $course->events()->where('verified', true)->paginate(10);
 
         return response()->json($events, 200);
     }

--- a/app/Http/Controllers/API/EventsAPIController.php
+++ b/app/Http/Controllers/API/EventsAPIController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Course;
+use App\Event;
+use Illuminate\Http\Request;
+
+use App\Http\Requests;
+use App\Http\Controllers\Controller;
+
+class EventsAPIController extends Controller
+{
+    /**
+     * Return a set of events associated with a course
+     *
+     * @param $course_id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index($course_id)
+    {
+        $course = Course::find($course_id);
+        $events = $course->events()->paginate(10);
+
+        return response()->json($events, 200);
+    }
+}

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -25,6 +25,7 @@ class Authenticate
     {
         $authenticated = true;
         $token = $request->header('x-access-token');
+
         if($token)
         {
             try
@@ -32,11 +33,11 @@ class Authenticate
                $var= JWTAuth::decode(new Token($token));
                 $user= User::findOrFail($var['id']);
                 Auth::setUser($user);
-
             }
             catch(TokenInvalidException $e)
             {
                 $authenticated = false;
+
             }
         }
         else if(Auth::guard($guard)->guest())

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -266,5 +266,9 @@ Route::group(['prefix' => 'api/v1', 'middleware' => ['cors']], function () {
      * Get the events of a specific course
      */
     Route::get('/events/{course_id}','API\EventsAPIController@index');
+    /*
+     * Create an event of a specific course
+     */
+    Route::post('/events/{course_id}','API\EventsAPIController@create');
 
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -262,5 +262,9 @@ Route::group(['prefix' => 'api/v1', 'middleware' => ['cors']], function () {
      * Home page data
      */
     Route::get('/home', 'ApiController@home');
+    /*
+     * Get the events of a specific course
+     */
+    Route::get('/events/{course_id}','API\EventsAPIController@index');
 
 });

--- a/composer.lock
+++ b/composer.lock
@@ -110,11 +110,9 @@
                 "image management",
                 "sdk"
             ],
-<<<<<<< HEAD
-            "time": "2017-04-03 08:28:38"
-=======
+
             "time": "2017-04-03T08:28:38+00:00"
->>>>>>> fd78d73be66b270efe30c76b7b0ebbba4041ecd9
+
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -572,11 +570,9 @@
                 "sftp",
                 "storage"
             ],
-<<<<<<< HEAD
-            "time": "2017-03-22 15:43:14"
-=======
+
             "time": "2017-03-22T15:43:14+00:00"
->>>>>>> fd78d73be66b270efe30c76b7b0ebbba4041ecd9
+
         },
         {
             "name": "monolog/monolog",
@@ -972,7 +968,7 @@
                     "role": "Developer"
                 },
                 {
-                    "name": "Hans-Jürgen Petrich",
+                    "name": "Hans-JÃ¼rgen Petrich",
                     "email": "petrich@tronic-media.com",
                     "role": "Developer"
                 }
@@ -2159,7 +2155,7 @@
             ],
             "authors": [
                 {
-                    "name": "François Zaninotto"
+                    "name": "FranÃ§ois Zaninotto"
                 }
             ],
             "description": "Faker is a PHP library that generates fake data for you.",
@@ -2254,7 +2250,7 @@
             ],
             "authors": [
                 {
-                    "name": "Pádraic Brady",
+                    "name": "PÃ¡draic Brady",
                     "email": "padraic.brady@gmail.com",
                     "homepage": "http://blog.astrumfutura.com"
                 },
@@ -3274,7 +3270,7 @@
             ],
             "authors": [
                 {
-                    "name": "Jean-François Simon",
+                    "name": "Jean-FranÃ§ois Simon",
                     "email": "jeanfrancois.simon@sensiolabs.com"
                 },
                 {


### PR DESCRIPTION
## In this PR
- End point for retrieving verified events of a specific course.
- End point for creating event of a specific course

## Some notes
- The default flow for creating a event is to post it and then the admins will review it and then approve this event.
- In order to create an event the creator should have an account on the website.
- Anyone can retrieve the verified events.

For the full docs of the apis please refer to [askafellow docs](https://askafellow1.restlet.io/#section_events)